### PR TITLE
add exit_code output of planetscale cli command

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,27 +1,29 @@
-name: 'Create Deploy Request'
-description: 'Creates a deploy request for a PlanetScale database.'
+name: "Create Deploy Request"
+description: "Creates a deploy request for a PlanetScale database."
 branding:
-  color: 'orange'
-  icon: 'database'
+  color: "orange"
+  icon: "database"
 inputs:
   database_name:
-    description: 'The name of the database.'
+    description: "The name of the database."
     required: true
   branch_name:
-    description: 'The name of the new branch.'
+    description: "The name of the new branch."
     required: true
   org_name:
-    description: 'The name of the organization that owns the database.'
+    description: "The name of the organization that owns the database."
     required: true
   deploy_to:
-    description: 'The target branch to merge changes into. Defaults to `main`.'
+    description: "The target branch to merge changes into. Defaults to `main`."
     required: false
 outputs:
   number:
-    description: 'The number of the deploy request.'
+    description: "The number of the deploy request."
+  exit_code:
+    description: "The exit code of the PlanetScale CLI command."
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
   args:
     - ${{ inputs.database_name }}
     - ${{ inputs.branch_name }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ if [ -n "$4" ];then
 fi
 
 CMDOUT=$(eval $command)
+echo "exit_code=$?" >> $GITHUB_OUTPUT
 
 number=$(jq -n "$CMDOUT" | jq '.number')
 echo "number=$number" >> $GITHUB_OUTPUT

--- a/readme.md
+++ b/readme.md
@@ -57,3 +57,4 @@ jobs:
 ## Outputs
 
 - `number` - The number of the deploy request that was created.
+- `exit_code` - The exit code of the Planetscale CLI command.


### PR DESCRIPTION
While trying use these github actions I found it very diffcult to do conditional work, since the returned number is null if a deploy request exists, and that is not easy to check for.
So adding the exit code (> 0 if it failed, is way easier to validate and check for.)

The reason is I manually create a github artifact to store this deploy_request number across workflow runs, and then download it later on production to deploy it.
If the number is null, it will just override the pending deploy_request and fail when merging to production. 