### PR TITLE
Pass CLI exit code to Actions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,5 +8,10 @@ fi
 
 CMDOUT=$(eval $command)
 
+ret=$?
+if [ $ret -ne 0 ]; then
+  exit $ret
+fi
+
 number=$(jq -n "$CMDOUT" | jq '.number')
 echo "number=$number" >> $GITHUB_OUTPUT

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: Create a deploy request
-        uses: planetscale/create-deploy-request-action@v1
+        uses: planetscale/create-deploy-request-action@v2
         id: create_deploy_request
         with:
           org_name: bmorrison-ps


### PR DESCRIPTION
This update will pass the exit code from the CLI operations up to the Actions platform. This will properly flag the workflow step as a failure if something goes wrong while executing.